### PR TITLE
feat: allow stateful preproc artifacts

### DIFF
--- a/numaprom/entities.py
+++ b/numaprom/entities.py
@@ -16,7 +16,9 @@ class Status(str, Enum):
     EXTRACTED = "extracted"
     PRE_PROCESSED = "pre_processed"
     INFERRED = "inferred"
+    THRESHOLD = "threshold_complete"
     POST_PROCESSED = "post_processed"
+    ARTIFACT_NOT_FOUND = "artifact_not_found"
 
 
 @dataclass(frozen=True)
@@ -25,7 +27,7 @@ class Metric:
     value: float
 
 
-@dataclass
+@dataclass(repr=False)
 class StreamPayload:
     uuid: str
     win_arr: Matrix
@@ -67,7 +69,7 @@ class StreamPayload:
         )
 
 
-@dataclass
+@dataclass(repr=False)
 class PrometheusPayload:
     timestamp_ms: int
     name: str

--- a/numaprom/prometheus.py
+++ b/numaprom/prometheus.py
@@ -71,7 +71,9 @@ class Prometheus:
 
         return results
 
-    def query_range_limit(self, query: str, start: float, end: float, step: int = 30) -> Optional[Dict]:
+    def query_range_limit(
+        self, query: str, start: float, end: float, step: int = 30
+    ) -> Optional[Dict]:
         data_points = (end - start) / step
 
         if data_points > 11000:
@@ -92,7 +94,9 @@ class Prometheus:
     def query(self, query: str) -> Optional[Dict]:
         results = []
         try:
-            response = requests.get(self.PROMETHEUS_SERVER + "/api/v1/query", params={"query": query})
+            response = requests.get(
+                self.PROMETHEUS_SERVER + "/api/v1/query", params={"query": query}
+            )
             if response:
                 results = response.json()["data"]["result"]
             else:

--- a/numaprom/tools.py
+++ b/numaprom/tools.py
@@ -122,7 +122,9 @@ def is_host_reachable(hostname: str, port=None, max_retries=5, sleep_sec=5) -> b
             get_ipv4_by_hostname(hostname, port)
         except socket.gaierror as ex:
             retries += 1
-            _LOGGER.warning("Failed to resolve hostname: %s: error: %r", hostname, ex, exc_info=True)
+            _LOGGER.warning(
+                "Failed to resolve hostname: %s: error: %r", hostname, ex, exc_info=True
+            )
             time.sleep(sleep_sec)
         else:
             return True
@@ -144,7 +146,9 @@ def load_model(skeys: Sequence[str], dkeys: Sequence[str]) -> Optional[ArtifactD
         return None
 
 
-def save_model(skeys: Sequence[str], dkeys: Sequence[str], model, **metadata) -> Optional[ModelVersion]:
+def save_model(
+    skeys: Sequence[str], dkeys: Sequence[str], model, **metadata
+) -> Optional[ModelVersion]:
     tracking_uri = os.getenv("TRACKING_URI", DEFAULT_TRACKING_URI)
     ml_registry = MLflowRegistry(tracking_uri=tracking_uri, artifact_type="pytorch")
     version = ml_registry.save(skeys=skeys, dkeys=dkeys, artifact=model, **metadata)

--- a/numaprom/tools.py
+++ b/numaprom/tools.py
@@ -147,10 +147,10 @@ def load_model(skeys: Sequence[str], dkeys: Sequence[str]) -> Optional[ArtifactD
 
 
 def save_model(
-    skeys: Sequence[str], dkeys: Sequence[str], model, **metadata
+    skeys: Sequence[str], dkeys: Sequence[str], model, artifact_type="pytorch", **metadata
 ) -> Optional[ModelVersion]:
     tracking_uri = os.getenv("TRACKING_URI", DEFAULT_TRACKING_URI)
-    ml_registry = MLflowRegistry(tracking_uri=tracking_uri, artifact_type="pytorch")
+    ml_registry = MLflowRegistry(tracking_uri=tracking_uri, artifact_type=artifact_type)
     version = ml_registry.save(skeys=skeys, dkeys=dkeys, artifact=model, **metadata)
     return version
 

--- a/numaprom/udf/window.py
+++ b/numaprom/udf/window.py
@@ -48,7 +48,9 @@ def window(_: str, datum: Datum) -> Optional[bytes]:
     buff_size = int(os.getenv("BUFF_SIZE", 10 * win_size))
 
     if buff_size < win_size:
-        raise ValueError(f"Redis list buffer size: {buff_size} is less than window length: {win_size}")
+        raise ValueError(
+            f"Redis list buffer size: {buff_size} is less than window length: {win_size}"
+        )
 
     key_map = create_composite_keys(msg)
     unique_key = ":".join(key_map.values())
@@ -60,7 +62,9 @@ def window(_: str, datum: Datum) -> Optional[bytes]:
         )
     except RedisConnectionError:
         _LOGGER.warning("Redis connection failed, recreating the redis client")
-        elements = __aggregate_window(unique_key, msg["timestamp"], value, win_size, buff_size, recreate=True)
+        elements = __aggregate_window(
+            unique_key, msg["timestamp"], value, win_size, buff_size, recreate=True
+        )
 
     if len(elements) < win_size:
         return None

--- a/numaprom/udsink/train.py
+++ b/numaprom/udsink/train.py
@@ -75,7 +75,9 @@ def train(datums: List[Datum]) -> Responses:
         namespace = payload["namespace"]
         metric_name = payload["name"]
 
-        _LOGGER.debug("%s - Starting Training for namespace: %s, metric: %s", _id, namespace, metric_name)
+        _LOGGER.debug(
+            "%s - Starting Training for namespace: %s, metric: %s", _id, namespace, metric_name
+        )
 
         is_new = _is_new_request(namespace, metric_name)
         if not is_new:

--- a/numaprom/udsink/train_rollout.py
+++ b/numaprom/udsink/train_rollout.py
@@ -91,7 +91,9 @@ def train_rollout(datums: List[Datum]) -> Responses:
         namespace = payload["namespace"]
         metric_name = payload["name"]
 
-        _LOGGER.debug("%s - Starting Training for namespace: %s, metric: %s", _id, namespace, metric_name)
+        _LOGGER.debug(
+            "%s - Starting Training for namespace: %s, metric: %s", _id, namespace, metric_name
+        )
 
         is_new = _is_new_request(namespace, metric_name)
         if not is_new:
@@ -114,7 +116,9 @@ def train_rollout(datums: List[Datum]) -> Responses:
         try:
             train_df = clean_data(_id, train_df, "hash_id")
         except KeyError:
-            _LOGGER.exception("%s - KeyError while data cleaning for train payload: %s", _id, payload)
+            _LOGGER.exception(
+                "%s - KeyError while data cleaning for train payload: %s", _id, payload
+            )
             responses.append(Response.as_success(_datum.id))
             continue
 

--- a/numaprom/udsink/train_rollout.py
+++ b/numaprom/udsink/train_rollout.py
@@ -7,10 +7,10 @@ import numpy as np
 import pandas as pd
 from numalogic.models.autoencoder import AutoencoderTrainer
 from numalogic.models.autoencoder.variants import SparseVanillaAE
-from numalogic.preprocess.transformer import LogTransformer
 from numalogic.tools.data import StreamingDataset
 from orjson import orjson
 from pynumaflow.sink import Datum, Responses, Response
+from sklearn.preprocessing import StandardScaler
 from torch.utils.data import DataLoader
 
 from numaprom.redis import get_redis_client
@@ -64,9 +64,9 @@ def _train_model(uuid, x, model_config):
 
 
 def _preprocess(x_raw):
-    clf = LogTransformer()
+    clf = StandardScaler()
     x_scaled = clf.fit_transform(x_raw)
-    return x_scaled
+    return x_scaled, clf
 
 
 def _is_new_request(namespace: str, metric: str) -> bool:
@@ -132,10 +132,18 @@ def train_rollout(datums: List[Datum]) -> Responses:
             responses.append(Response.as_success(_datum.id))
             continue
 
-        x_train = _preprocess(train_df.to_numpy())
+        x_train, preproc_clf = _preprocess(train_df.to_numpy())
         model = _train_model(_id, x_train, model_config)
 
         skeys = [namespace, metric_name]
+
+        version = save_model(
+            skeys=skeys, dkeys=["preproc"], model=preproc_clf, artifact_type="sklearn"
+        )
+        _LOGGER.info(
+            "%s - Preproc model saved with skeys: %s with version: %s", _id, skeys, version
+        )
+
         version = save_model(skeys=skeys, dkeys=[model_config["model_name"]], model=model)
         _LOGGER.info("%s - Model saved with skeys: %s with version: %s", _id, skeys, version)
         responses.append(Response.as_success(_datum.id))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "numalogic-prometheus"
-version = "0.1.3a0"
+version = "0.1.3"
 description = "ML inference on numaflow using numalogic on Prometheus metrics"
 authors = ["Numalogic developers"]
 packages = [{ include = "numaprom" }]
@@ -45,7 +45,7 @@ pytest-cov = "^4.0"
 freezegun = "^1.2.2"
 
 [tool.black]
-line-length = 110
+line-length = 100
 include = '\.pyi?$'
 exclude = '''
 /(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "numalogic-prometheus"
-version = "0.1.3"
+version = "0.1.3a1"
 description = "ML inference on numaflow using numalogic on Prometheus metrics"
 authors = ["Numalogic developers"]
 packages = [{ include = "numaprom" }]

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -27,7 +27,9 @@ def as_datum(data: Union[str, bytes, dict], msg_id="1") -> Datum:
     elif type(data) == dict:
         data = json.dumps(data)
 
-    return Datum(sink_msg_id=msg_id, value=data, event_time=datetime.now(), watermark=datetime.now())
+    return Datum(
+        sink_msg_id=msg_id, value=data, event_time=datetime.now(), watermark=datetime.now()
+    )
 
 
 @patch.dict(METRIC_CONFIG, return_mock_metric_config())

--- a/tests/tools.py
+++ b/tests/tools.py
@@ -58,7 +58,7 @@ def get_inference_input(data_path: str, prev_artifact_found=True) -> Messages:
         for msg in preproc_input.items():
             _in = get_datum(msg.value)
             handler_ = HandlerFactory.get_handler("preprocess")
-            _out = handler_(None, _in)
+            _out = handler_("", _in)
             if _out.items()[0].key != DROP:
                 out.append(_out.items()[0])
     return out

--- a/tests/udf/test_inference.py
+++ b/tests/udf/test_inference.py
@@ -27,9 +27,11 @@ STREAM_DATA_PATH = os.path.join(DATA_DIR, "stream.json")
 @patch.dict(METRIC_CONFIG, return_mock_metric_config())
 class TestInference(unittest.TestCase):
     @classmethod
-    def setUpClass(cls) -> None:
+    @patch.dict(METRIC_CONFIG, return_mock_metric_config())
+    def setUp(cls) -> None:
         redis_client.flushall()
         cls.inference_input = get_inference_input(STREAM_DATA_PATH)
+        assert cls.inference_input.items(), print("input items is empty", cls.inference_input)
 
     @freeze_time("2022-02-20 12:00:00")
     @patch.object(MLflowRegistry, "load", Mock(return_value=return_mock_lstmae()))

--- a/tests/udf/test_inference.py
+++ b/tests/udf/test_inference.py
@@ -28,7 +28,7 @@ STREAM_DATA_PATH = os.path.join(DATA_DIR, "stream.json")
 class TestInference(unittest.TestCase):
     @classmethod
     @patch.dict(METRIC_CONFIG, return_mock_metric_config())
-    def setUp(cls) -> None:
+    def setUpClass(cls) -> None:
         redis_client.flushall()
         cls.inference_input = get_inference_input(STREAM_DATA_PATH)
         assert cls.inference_input.items(), print("input items is empty", cls.inference_input)

--- a/tests/udf/test_postprocess.py
+++ b/tests/udf/test_postprocess.py
@@ -33,10 +33,12 @@ class TestPostProcess(unittest.TestCase):
     )
 
     @classmethod
+    @patch.dict(METRIC_CONFIG, return_mock_metric_config())
     @freeze_time("2022-02-20 12:00:00")
     def setUpClass(cls) -> None:
         redis_client.flushall()
         cls.postproc_input = get_postproc_input(STREAM_DATA_PATH)
+        assert cls.postproc_input.items(), print("input items is empty", cls.postproc_input)
 
     def setUp(self) -> None:
         redis_client.flushall()

--- a/tests/udf/test_postprocess.py
+++ b/tests/udf/test_postprocess.py
@@ -11,7 +11,6 @@ from tests.tools import (
     get_postproc_input,
     return_mock_metric_config,
     get_datum,
-    return_mock_lstmae,
 )
 from numaprom.udf.postprocess import postprocess, save_to_redis
 
@@ -35,8 +34,6 @@ class TestPostProcess(unittest.TestCase):
 
     @classmethod
     @freeze_time("2022-02-20 12:00:00")
-    @patch.dict(METRIC_CONFIG, return_mock_metric_config())
-    @patch("numalogic.registry.MLflowRegistry.load", return_mock_lstmae)
     def setUpClass(cls) -> None:
         redis_client.flushall()
         cls.postproc_input = get_postproc_input(STREAM_DATA_PATH)

--- a/tests/udf/test_preprocess.py
+++ b/tests/udf/test_preprocess.py
@@ -1,12 +1,13 @@
 import os
 import unittest
-from unittest.mock import patch
+from unittest.mock import patch, Mock
 
+from numalogic.registry import MLflowRegistry
 from orjson import orjson
 
 from numaprom._constants import TESTS_DIR, METRIC_CONFIG
 from numaprom.entities import Status, StreamPayload
-from tests.tools import get_prepoc_input, return_mock_metric_config, get_datum
+from tests.tools import get_prepoc_input, return_mock_metric_config, get_datum, return_preproc_clf
 
 # Make sure to import this in the end
 from numaprom.udf.preprocess import preprocess
@@ -23,7 +24,8 @@ class TestPreprocess(unittest.TestCase):
     def setUpClass(cls) -> None:
         cls.preproc_input = get_prepoc_input(STREAM_DATA_PATH)
 
-    def test_preprocess1(self):
+    @patch.object(MLflowRegistry, "load", Mock(return_value=return_preproc_clf()))
+    def test_preprocess(self):
         for msg in self.preproc_input.items():
             _in = get_datum(msg.value)
             _out = preprocess("", _in)
@@ -31,6 +33,18 @@ class TestPreprocess(unittest.TestCase):
             payload = StreamPayload(**orjson.loads(out_data))
 
             self.assertEqual(payload.status, Status.PRE_PROCESSED)
+            self.assertTrue(payload.win_arr)
+            self.assertTrue(payload.win_ts_arr)
+
+    @patch.object(MLflowRegistry, "load", Mock(return_value=None))
+    def test_preprocess_no_clf(self):
+        for msg in self.preproc_input.items():
+            _in = get_datum(msg.value)
+            _out = preprocess("", _in)
+            out_data = _out.items()[0].value.decode("utf-8")
+            payload = StreamPayload(**orjson.loads(out_data))
+
+            self.assertEqual(payload.status, Status.ARTIFACT_NOT_FOUND)
             self.assertTrue(payload.win_arr)
             self.assertTrue(payload.win_ts_arr)
 


### PR DESCRIPTION
Signed-off-by: Avik Basu <ab93@users.noreply.github.com>

- allow stateful preprocessing artifacts that will be saved in mlflow
- use StandardScaler as a default
- set the status as `ARTIFACT_NOT_FOUND` in preproc to pass on this info to inference

