### PR TITLE
fix: static score calculation to use the correct limit from conf

### DIFF
--- a/numaprom/tools.py
+++ b/numaprom/tools.py
@@ -276,10 +276,11 @@ class WindowScorer:
         metric_conf: MetricConf instance
     """
 
-    __slots__ = ("static_wt", "model_wt", "postproc_clf")
+    __slots__ = ("static_wt", "static_limit", "model_wt", "postproc_clf")
 
     def __init__(self, metric_conf: MetricConf):
         self.static_wt = metric_conf.static_threshold_wt
+        self.static_limit = metric_conf.static_threshold
         self.model_wt = 1.0 - self.static_wt
 
         postproc_factory = PostprocessFactory()
@@ -327,7 +328,7 @@ class WindowScorer:
         Returns:
             Score for the window
         """
-        static_scores = calculate_static_thresh(payload, self.static_wt)
+        static_scores = calculate_static_thresh(payload, self.static_limit)
         static_winscore = np.mean(static_scores)
         return self.postproc_clf.transform(static_winscore)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "numalogic-prometheus"
-version = "0.2.1"
+version = "0.2.2"
 description = "ML inference on numaflow using numalogic on Prometheus metrics"
 authors = ["Numalogic developers"]
 packages = [{ include = "numaprom" }]

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,15 +1,20 @@
 import os
 import socket
 import unittest
+from collections import OrderedDict
 from unittest.mock import patch, Mock
+
+import numpy as np
 
 from numaprom import tools
 from numaprom._constants import TESTS_DIR
+from numaprom.entities import StreamPayload
 from numaprom.tools import (
     is_host_reachable,
     get_metric_config,
     get_service_config,
     get_unified_config,
+    WindowScorer,
 )
 from tests.tools import mock_configs
 
@@ -94,3 +99,22 @@ class TestTools(unittest.TestCase):
         # default config - will not have unified config
         unified_config = get_unified_config(metric="random", namespace="abc")
         self.assertFalse(unified_config)
+
+
+@patch.object(tools, "get_all_configs", Mock(return_value=mock_configs()))
+class TestWindowScorer(unittest.TestCase):
+    def test_get_winscore(self):
+        metric_conf = get_metric_config(
+            metric="namespace_argo_rollout_error_rate", namespace="sandbox_numalogic_demo2"
+        )
+        stream = np.random.uniform(low=1, high=2, size=(10, 1))
+        payload = StreamPayload(
+            uuid="123",
+            composite_keys=OrderedDict({"namespace": "sandbox_numalogic_demo2"}),
+            win_raw_arr=stream,
+            win_arr=stream.copy(),
+            win_ts_arr=list(range(10)),
+        )
+        winscorer = WindowScorer(metric_conf)
+        final_score = winscorer.get_final_winscore(payload)
+        self.assertLess(final_score, 3.0)


### PR DESCRIPTION
Fixes a bug where the calculation of the static score was based on the static weight, as opposed to the static limit from config.
