### PR TITLE
fix: duplicate payload generation for the same timestamp and composite key

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ setup:
 	poetry install --with dev --all-extras
 
 test:
-	poetry run python -m unittest discover -s tests -t .
+	poetry run pytest tests/
 
 requirements:
 	poetry export -f requirements.txt --output requirements.txt --without-hashes

--- a/numaprom/udf/window.py
+++ b/numaprom/udf/window.py
@@ -47,7 +47,6 @@ def __aggregate_window(
     """
     redis_client = get_redis_client(HOST, PORT, password=AUTH, recreate=recreate)
     with redis_client.pipeline() as pl:
-        print(ts, key)
         pl.zadd(key, {f"{value}::{ts}": ts})
         pl.zremrangebyrank(key, -(buff_size + 10), -buff_size)
         pl.zrange(key, -win_size, -1, withscores=True, score_cast_func=int)

--- a/numaprom/udf/window.py
+++ b/numaprom/udf/window.py
@@ -1,7 +1,7 @@
 import os
 import time
 import uuid
-from typing import List, Tuple, Optional
+from typing import Optional
 
 import numpy as np
 import numpy.typing as npt
@@ -36,14 +36,25 @@ def _clean_arr(
     return np.nan_to_num(arr, nan=replace_val, posinf=inf_replace, neginf=-inf_replace)
 
 
-def __aggregate_window(key, ts, value, win_size, buff_size, recreate) -> List[Tuple[float, float]]:
+def __aggregate_window(
+    key: str, ts: str, value: float, win_size: int, buff_size: int, recreate: bool
+) -> list[tuple[float, float]]:
+    """
+    Adds an element to the sliding window using a redis sorted set.
+
+    Returns an empty list if adding the element does not create a new entry
+    to the set.
+    """
     redis_client = get_redis_client(HOST, PORT, password=AUTH, recreate=recreate)
     with redis_client.pipeline() as pl:
+        print(ts, key)
         pl.zadd(key, {f"{value}::{ts}": ts})
         pl.zremrangebyrank(key, -(buff_size + 10), -buff_size)
         pl.zrange(key, -win_size, -1, withscores=True, score_cast_func=int)
         out = pl.execute()
-    _window = out[-1]
+    _is_new, _, _window = out
+    if not _is_new:
+        return []
     _window = list(map(lambda x: (float(x[0].split("::")[0]), x[1]), _window))
     return _window
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "numalogic-prometheus"
-version = "0.2.5"
+version = "0.2.6"
 description = "ML inference on numaflow using numalogic on Prometheus metrics"
 authors = ["Numalogic developers"]
 packages = [{ include = "numaprom" }]

--- a/tests/resources/data/stream.json
+++ b/tests/resources/data/stream.json
@@ -287,5 +287,51 @@
         "name": "namespace_app_rollouts_http_request_latency",
         "timestamp": "1654121208989",
         "value": "18"
+    },
+    {
+     "labels": {
+         "__name__":"namespace_app_rollouts_http_request_error_rate",
+         "app":"o11y-fuzzy-gql-federation",
+         "intuit_alert":"true",
+         "namespace":"dev-devx-o11yfuzzygqlfederation-usw2-stg",
+         "numalogic":"true",
+         "prometheus":"addon-metricset-ns/k8s-prometheus",
+         "prometheus_replica":"prometheus-k8s-prometheus-1",
+         "rollouts_pod_template_hash":"79b6c65945"
+     },
+     "name":"namespace_app_rollouts_http_request_error_rate",
+     "timestamp":"1680030431883",
+     "value":"0.575556508537336"
+    },
+    {
+    "labels": {
+        "__name__":"namespace_app_rollouts_http_request_error_rate",
+        "app":"o11y-fuzzy-gql-federation",
+        "intuit_alert":"true",
+        "namespace":"dev-devx-o11yfuzzygqlfederation-usw2-stg",
+        "numalogic":"true",
+        "prometheus":"addon-metricset-ns/k8s-prometheus",
+        "prometheus_replica":"prometheus-k8s-prometheus-1",
+        "rollouts_pod_template_hash":"79b6c65945"
+    },
+    "name":"namespace_app_rollouts_http_request_error_rate",
+    "timestamp":"1680030461883",
+    "value":"0"
+    },
+    {
+    "labels": {
+        "__name__":"namespace_app_rollouts_http_request_error_rate",
+        "app":"o11y-fuzzy-gql-federation",
+        "intuit_alert":"true",
+        "namespace":"dev-devx-o11yfuzzygqlfederation-usw2-stg",
+        "numalogic":"true",
+        "prometheus":"addon-metricset-ns/k8s-prometheus",
+        "prometheus_replica":"prometheus-k8s-prometheus-0",
+        "rollouts_pod_template_hash":"79b6c65945"
+    },
+    "name":"namespace_app_rollouts_http_request_error_rate",
+    "timestamp":"1680030461883",
+    "value":"0"
     }
+
 ]

--- a/tests/resources/data/stream.json
+++ b/tests/resources/data/stream.json
@@ -291,9 +291,9 @@
     {
      "labels": {
          "__name__":"namespace_app_rollouts_http_request_error_rate",
-         "app":"o11y-fuzzy-gql-federation",
+         "app":"some-numaprom-app",
          "intuit_alert":"true",
-         "namespace":"dev-devx-o11yfuzzygqlfederation-usw2-stg",
+         "namespace":"some-numaprom-app-stg",
          "numalogic":"true",
          "prometheus":"addon-metricset-ns/k8s-prometheus",
          "prometheus_replica":"prometheus-k8s-prometheus-1",
@@ -306,9 +306,9 @@
     {
     "labels": {
         "__name__":"namespace_app_rollouts_http_request_error_rate",
-        "app":"o11y-fuzzy-gql-federation",
+        "app":"some-numaprom-app",
         "intuit_alert":"true",
-        "namespace":"dev-devx-o11yfuzzygqlfederation-usw2-stg",
+        "namespace":"some-numaprom-app-stg",
         "numalogic":"true",
         "prometheus":"addon-metricset-ns/k8s-prometheus",
         "prometheus_replica":"prometheus-k8s-prometheus-1",
@@ -321,9 +321,9 @@
     {
     "labels": {
         "__name__":"namespace_app_rollouts_http_request_error_rate",
-        "app":"o11y-fuzzy-gql-federation",
+        "app":"some-numaprom-app",
         "intuit_alert":"true",
-        "namespace":"dev-devx-o11yfuzzygqlfederation-usw2-stg",
+        "namespace":"some-numaprom-app-stg",
         "numalogic":"true",
         "prometheus":"addon-metricset-ns/k8s-prometheus",
         "prometheus_replica":"prometheus-k8s-prometheus-0",

--- a/tests/tools.py
+++ b/tests/tools.py
@@ -18,7 +18,7 @@ from numalogic.registry import ArtifactData, MLflowRegistry
 from pynumaflow.function import Datum, Messages
 from pynumaflow.function._dtypes import DROP
 
-from numaprom._constants import TESTS_DIR, POSTPROC_VTX_KEY, CONFIG_DIR, DEFAULT_CONFIG_DIR
+from numaprom._constants import TESTS_DIR, POSTPROC_VTX_KEY, DEFAULT_CONFIG_DIR
 from numaprom.factory import HandlerFactory
 from numaprom import NumapromConf
 

--- a/tests/udf/test_postprocess.py
+++ b/tests/udf/test_postprocess.py
@@ -26,8 +26,7 @@ STREAM_DATA_PATH = os.path.join(DATA_DIR, "stream.json")
 class TestPostProcess(unittest.TestCase):
     postproc_input = None
 
-    @classmethod
-    def setUpClass(cls) -> None:
+    def setUp(self) -> None:
         redis_client.flushall()
 
     @freeze_time("2022-02-20 12:00:00")

--- a/tests/udf/test_preprocess.py
+++ b/tests/udf/test_preprocess.py
@@ -27,6 +27,7 @@ class TestPreprocess(unittest.TestCase):
     @classmethod
     @patch.object(tools, "get_all_configs", Mock(return_value=mock_configs()))
     def setUpClass(cls) -> None:
+        redis_client.flushall()
         cls.preproc_input = get_prepoc_input(STREAM_DATA_PATH)
         assert cls.preproc_input.items(), print("input items is empty", cls.preproc_input)
 

--- a/tests/udf/test_threshold.py
+++ b/tests/udf/test_threshold.py
@@ -9,6 +9,7 @@ from numalogic.registry import MLflowRegistry
 from numaprom import tools
 from numaprom._constants import TESTS_DIR
 from numaprom.entities import Status, StreamPayload, TrainerPayload, Header
+from tests import redis_client
 from tests.tools import (
     get_threshold_input,
     get_datum,
@@ -26,6 +27,9 @@ STREAM_DATA_PATH = os.path.join(DATA_DIR, "stream.json")
 @patch("numaprom.tools.set_aws_session", Mock(return_value=None))
 @patch.object(tools, "get_all_configs", Mock(return_value=mock_configs()))
 class TestThreshold(unittest.TestCase):
+    def setUp(self) -> None:
+        redis_client.flushall()
+
     @freeze_time("2022-02-20 12:00:00")
     @patch.object(MLflowRegistry, "load", Mock(return_value=return_threshold_clf()))
     def test_threshold(self):
@@ -76,6 +80,7 @@ class TestThreshold(unittest.TestCase):
     @patch.object(MLflowRegistry, "load", Mock(return_value=None))
     def test_threshold_no_clf(self):
         thresh_input = get_threshold_input(STREAM_DATA_PATH)
+        print(thresh_input)
         assert thresh_input.items(), print("input items is empty", thresh_input)
 
         for msg in thresh_input.items():

--- a/tests/udf/test_window.py
+++ b/tests/udf/test_window.py
@@ -32,6 +32,17 @@ class TestWindow(unittest.TestCase):
                 payload = StreamPayload(**orjson.loads(_out))
                 self.assertTrue(payload)
 
+    def test_window_duplicate_element(self):
+        uuids = set()
+        for idx, data in enumerate(self.input_stream[-3:]):
+            _out = window("", get_datum(data))
+            if not _out.items()[0].key == DROP:
+                _out = _out.items()[0].value.decode("utf-8")
+                payload = StreamPayload(**orjson.loads(_out))
+                uuids.add(payload.uuid)
+                self.assertTrue(payload)
+        self.assertEqual(1, len(uuids))
+
     @mockenv(BUFF_SIZE="1")
     def test_window_err(self):
         with self.assertRaises(ValueError):


### PR DESCRIPTION
Fixes an issue where a duplicate payload (with a different uuid) for the same timestamp, value and composite key is generated, thus leading to multiple publishing to Prometheus. This was happening when we get almost the exact request multiple times, e.g. data coming from different prometheus replica. 