### PR TITLE
fix: catch inference errors and send for static thresholding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ setup:
 	poetry install --with dev --all-extras
 
 test:
-	poetry run pytest tests/
+	poetry run pytest -v tests/
 
 requirements:
 	poetry export -f requirements.txt --output requirements.txt --without-hashes

--- a/numaprom/entities.py
+++ b/numaprom/entities.py
@@ -21,6 +21,7 @@ class Status(str, Enum):
     POST_PROCESSED = "post_processed"
     ARTIFACT_NOT_FOUND = "artifact_not_found"
     ARTIFACT_STALE = "artifact_is_stale"
+    RUNTIME_ERROR = "runtime_error"
 
 
 class Header(str, Enum):

--- a/numaprom/udf/threshold.py
+++ b/numaprom/udf/threshold.py
@@ -50,8 +50,8 @@ def threshold(_: str, datum: Datum) -> list[tuple[str, bytes]]:
 
     # Check if payload needs static inference
     if payload.header == Header.STATIC_INFERENCE:
-        _LOGGER.debug(
-            "%s - Models not found in the previous steps, performing static thresholding. Keys: %s",
+        _LOGGER.info(
+            "%s - Sending to trainer and performing static thresholding. Keys: %s",
             payload.uuid,
             payload.composite_keys,
         )
@@ -95,6 +95,6 @@ def threshold(_: str, datum: Datum) -> list[tuple[str, bytes]]:
 
     _LOGGER.info("%s - Sending Payload: %r ", payload.uuid, payload)
     _LOGGER.debug(
-        "%s - Time taken in threshold: %.4f", payload.uuid, time.perf_counter() - _start_time
+        "%s - Time taken in threshold: %.4f sec", payload.uuid, time.perf_counter() - _start_time
     )
     return messages

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "numalogic-prometheus"
-version = "0.3.1a0"
+version = "0.3.1"
 description = "ML inference on numaflow using numalogic on Prometheus metrics"
 authors = ["Numalogic developers"]
 packages = [{ include = "numaprom" }]


### PR DESCRIPTION
Previously if there were any config changes, or inference errors the exception will be unhandled. This change makes sure that if that happens,

1. Perform static thresholding
2. Send for retraining
