### PR TITLE
fix: prometheus fetcher

### DIFF
--- a/numaprom/clients/prometheus.py
+++ b/numaprom/clients/prometheus.py
@@ -67,10 +67,8 @@ class Prometheus:
         if data_points > 0:
             response = self.query_range_limit(query, temp_start, end)
             if results:
-                LOGGER.debug("Prometheus query returned results.")
                 results.append(response)
             else:
-                LOGGER.debug("Prometheus query has returned empty results.")
                 results = response
         return results
 
@@ -90,6 +88,7 @@ class Prometheus:
                 params={"query": query, "start": start, "end": end, "step": f"{step}s"},
             )
             results = response.json()["data"]["result"]
+            LOGGER.debug("Prometheus query has returned results for {results} metric series.", results=len(results))
         except Exception as ex:
             LOGGER.exception("Prometheus error: %r", ex)
         return results

--- a/tests/test_prometheus.py
+++ b/tests/test_prometheus.py
@@ -6,8 +6,36 @@ from unittest.mock import patch, Mock, MagicMock
 from numaprom.clients.prometheus import Prometheus
 
 
+def mock_multiple_metrics(*_, **__):
+    result = [
+        {
+            "metric": {
+                "__name__": "namespace_app_rollouts_http_request_error_rate",
+                "assetAlias": "sandbox.numalogic.demo",
+                "numalogic": "true",
+                "namespace": "sandbox-numalogic-demo",
+                "rollouts_pod_template_hash": "7b4b4f9f9d",
+            },
+            "values": [[1656334767.73, "14.744611739611193"], [1656334797.73, "14.73040822323633"]],
+        },
+        {
+            "metric": {
+                "__name__": "namespace_app_rollouts_http_request_error_rate",
+                "assetAlias": "sandbox.numalogic.demo",
+                "numalogic": "true",
+                "namespace": "sandbox-numalogic-demo",
+                "rollouts_pod_template_hash": "5b4b4f9f9d",
+            },
+            "values": [[1656334767.73, "14.744611739611193"], [1656334797.73, "14.73040822323633"]],
+
+        }
+    ]
+
+    return result
+
+
 def mock_query_range(*_, **__):
-    result = {
+    result = [{
         "metric": {
             "__name__": "namespace_asset_pod_cpu_utilization",
             "assetAlias": "sandbox.numalogic.demo",
@@ -15,7 +43,7 @@ def mock_query_range(*_, **__):
             "namespace": "sandbox-numalogic-demo",
         },
         "values": [[1656334767.73, "14.744611739611193"], [1656334797.73, "14.73040822323633"]],
-    }
+    }]
 
     return result
 
@@ -34,7 +62,7 @@ def mock_response(*_, **__):
                         "numalogic": "true",
                         "namespace": "sandbox-numalogic-demo",
                     },
-                    "value": [1666730247.616, "0.7627805793186443"],
+                    "values": [[1656334767.73, "14.744611739611193"], [1656334797.73, "14.73040822323633"]],
                 }
             ],
         },
@@ -62,7 +90,7 @@ class TestPrometheus(unittest.TestCase):
             start=self.start,
             end=self.end,
         )
-        self.assertEqual(_out.shape, (2, 1))
+        self.assertEqual(_out.shape, (2, 2))
 
     @patch.object(Prometheus, "query_range", Mock(return_value=mock_query_range()))
     def test_query_metric2(self):
@@ -72,7 +100,7 @@ class TestPrometheus(unittest.TestCase):
             start=self.start,
             end=self.end,
         )
-        self.assertEqual(_out.shape, (2, 1))
+        self.assertEqual(_out.shape, (2, 2))
 
     @patch.object(Prometheus, "query_range", Mock(return_value=mock_query_range()))
     def test_query_metric3(self):
@@ -83,7 +111,19 @@ class TestPrometheus(unittest.TestCase):
             start=self.start,
             end=self.end,
         )
-        self.assertEqual(_out.shape, (2, 2))
+        self.assertEqual(_out.shape, (2, 3))
+
+    @patch.object(Prometheus, "query_range", Mock(return_value=mock_multiple_metrics()))
+    def test_query_metric4(self):
+        _out = self.prom.query_metric(
+            metric_name="namespace_app_pod_http_server_requests_errors",
+            labels_map={"namespace": "sandbox-numalogic-demo"},
+            return_labels=["rollouts_pod_template_hash"],
+            start=self.start,
+            end=self.end,
+        )
+        self.assertEqual(_out.shape, (4, 3))
+        self.assertEqual(_out["rollouts_pod_template_hash"].unique().shape[0], 2)
 
     @patch.object(requests, "get", Mock(return_value=mock_response()))
     def test_query_range(self):
@@ -92,7 +132,8 @@ class TestPrometheus(unittest.TestCase):
             start=self.start,
             end=self.end,
         )
-        self.assertEqual(len(_out), 2)
+        self.assertEqual(len(_out), 1)
+        self.assertEqual(len(_out[0]["values"]), 2)
 
     @patch.object(requests, "get", Mock(return_value=mock_response()))
     def test_query(self):


### PR DESCRIPTION
Explain what this PR does.

Added changes for fixing prometheus fetcher when fetching multiple time series. Every new label for metric is considered a new time series, and results in multiple metrics while fetching.